### PR TITLE
Also upload pubkey

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,6 +20,16 @@
   become: "{{ passwordless_ssh_become }}"
   become_user: "{{ passwordless_ssh_become_user }}"
 
+- name: copy public key to remote SSH dir
+  copy:
+    content: "{{ _public_key }}"
+    dest: "{{ passwordless_ssh_user_home }}/.ssh/\
+           {{ passwordless_ssh_remote_key_file }}.pub"
+    mode: 0600
+    owner: "{{ passwordless_ssh_user }}"
+  become: "{{ passwordless_ssh_become }}"
+  become_user: "{{ passwordless_ssh_become_user }}"
+
 - name: update known hosts with the other hosts in this current group
   known_hosts:
     path: "{{ passwordless_ssh_user_home }}/.ssh/known_hosts"


### PR DESCRIPTION
In some instances it is important to have the pubkey uploaded to the remote system, as well. This does that.