### PR TITLE
Add support for distributing host keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,22 @@ Currently the following variables are supported:
 * `passwordless_ssh_extra_hosts` - an array of hostnames and/or IP addresses that
   ought to be configured to join in the pubkey auth round-robin fun. Defaults to
   an empty list
+* `passwordless_ssh_update_known_hosts` - Defaults to true. Whether or not to add
+  known host keys to `known_hosts` file in the configured dir on all hosts in the play.
+* `passwordless_ssh_host_keys` - Defaults to empty array (`[]`). Should be set to an
+  array of host keys to add to hosts if `passwordless_ssh_update_known_hosts` is true.
+  See the "Host Key Notes" section below for details on the format for this array.
+* `passwordless_ssh_hash_known_hosts` - Defaults to false. Whether or not to
+  hash hostnames when adding entries to the `known_hosts` file.
+* `passwordless_ssh_gather_host_keys` - Defaults to false. Whether or not to
+  automatically gather host keys from all hosts (play hosts + extra hosts).
+  **This is insecure, as no host key fingerprint validation is done.** Host keys
+  are gathered using the `ssh-keyscan` tool, bundled with ssh. Each host is
+  implicitly trusted to be honest when asked what its host keys are, which makes
+  this vulnerable to man-in-the-middle attacks. Use of `passwordless_ssh_host_keys`
+  is recommended, but this is extremely useful for e.g. testing clusters and other
+  ephemeral or non-production use-cases. Gathered keys will be appended to
+  `passwordless_ssh_host_keys`.
 * `passwordless_ssh_become` - Defaults to true. Use sudo/become to change to an
   admin user. This is necessary if you are not logging in as the user who will be
   setup with the access.
@@ -47,6 +63,16 @@ Currently the following variables are supported:
   is changed to not match `passwordless_ssh_user` then unpredictable results can
   be seen when the user later attempts to connect due to potential mismatches in
   the pubkeys inserted to `.ssh/known_hosts`.
+
+Host Key Notes
+--------------
+
+The format of host keys is as seen in an actual `known_hosts` file, or in the output
+of the `ssh-keyscan` command. The input format expected by this role is the basic
+`hostname keytype pubkey` format, with unhashed host names. All other host key lines
+in `passwordless_ssh_host_keys` should match the key formats supported by the
+[known_hosts](https://docs.ansible.com/ansible/latest/modules/known_hosts_module.html)
+ansible module.
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,11 +18,14 @@
 # as that will be utilized to set known_hosts values in one of the tasks in this
 # role.
 passwordless_ssh_user: root
+
 # The home directory for the user who is being configured.
 passwordless_ssh_user_home: /root
+
 # Name that the private key file will be uploaded to. This should match the
 # key type, by default (id-rsa, id_dsa, etc).
 passwordless_ssh_remote_key_file: id_rsa
+
 # By default all hosts in the current play will be configured to this SSH
 # arrangement. Additional hosts that you want can be added to this array. The
 # values used here should be resolvable as hostnames or IP addresses as they
@@ -30,9 +33,16 @@ passwordless_ssh_remote_key_file: id_rsa
 # into the known_hosts file using the value of this array.
 passwordless_ssh_extra_hosts: []
 
+# Supporting vars for populating known_hosts with host keys
+passwordless_ssh_update_known_hosts: true
+passwordless_ssh_hash_known_hosts: false
+passwordless_ssh_gather_host_keys: false
+passwordless_ssh_host_keys: []
+
 # Whether or not to use the `become` feature of Ansible to gain admin privileges
 # over the user directory where SSH is being configured
 passwordless_ssh_become: true
+
 # The user to sudo/become. If this gets changed from being the same as the user
 # then unexpected things can happen when setting up the known_hosts, as the
 # connections will be performed as a different user than the one who will be

--- a/tasks/gather_host_keys.yml
+++ b/tasks/gather_host_keys.yml
@@ -1,0 +1,27 @@
+# resolve inventory hostnames to their fqdn, since these lookups
+# will be done from the perspective of the remote host, where the
+# inventory hostname may not resolve
+- name: Collect host names for gathering host keys
+  set_fact:
+    _ssh_gather_hosts: |
+      {{ (ansible_play_batch |
+         map('extract', hostvars, 'ansible_fqdn') |
+         list) + passwordless_ssh_extra_hosts }}
+
+# ssh-keyscan accepts multiple hosts, so we could potentially get all
+# keys for all hosts in one shot, but iterating over hosts provides
+# better feedback at a low overhead cost
+- name: Gather host keys
+  command: ssh-keyscan {{ item }}
+  register: _ssh_host_keyscan
+  with_items: "{{ _ssh_gather_hosts }}"
+  # fact gathering, report no change
+  changed_when: false
+
+# reduce keyscan result to a list of host key entries, which is
+# the expected structure of passwordless_ssh_host_keys.
+- name: Update host keys list with gathered keys
+  set_fact:
+    passwordless_ssh_host_keys: |
+      {{ item.stdout_lines + passwordless_ssh_host_keys }}
+  with_items: "{{ _ssh_host_keyscan.results }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,22 +30,22 @@
   become: "{{ passwordless_ssh_become }}"
   become_user: "{{ passwordless_ssh_become_user }}"
 
-- name: update known hosts with the other hosts in this current group
-  known_hosts:
-    path: "{{ passwordless_ssh_user_home }}/.ssh/known_hosts"
-    name: "{{ hostvars[item]['ansible_host'] | default(item) }}"
-    key: "{{ hostvars[item]['ansible_host'] | default(item)}} {{ _public_key }}"
-  with_items: "{{ play_hosts }}"
-  become: "{{ passwordless_ssh_become }}"
-  become_user: "{{ passwordless_ssh_become_user }}"
-  changed_when: false
+- block:
+    - include_tasks: gather_host_keys.yml
+      when: passwordless_ssh_gather_host_keys
 
-- name: update known hosts with the other hosts in this current group
-  known_hosts:
-    path: "{{ passwordless_ssh_user_home }}/.ssh/known_hosts"
-    name: "{{ item }}"
-    key: "{{ item }} {{ _public_key }}"
-  with_items: "{{ passwordless_ssh_extra_hosts }}"
-  become: "{{ passwordless_ssh_become }}"
-  become_user: "{{ passwordless_ssh_become_user }}"
-  changed_when: false
+    - name: update known hosts with all host keys
+      known_hosts:
+        path: "{{ passwordless_ssh_user_home }}/.ssh/known_hosts"
+        # The host name is the first element of the key line being added.
+        # Multiple host names are separated by a comma, and hostnames
+        # are separated from the keytype by a space, so split on space
+        # then comma and take the first result.
+        name: "{{ item.split().0.split(',').0 }}"
+        key: "{{ item }}"
+        hash_host: "{{ passwordless_ssh_hash_known_hosts }}"
+      with_items: "{{ passwordless_ssh_host_keys }}"
+      become: "{{ passwordless_ssh_become }}"
+      become_user: "{{ passwordless_ssh_become_user }}"
+      changed_when: false
+  when: passwordless_ssh_update_known_hosts


### PR DESCRIPTION
This is arguably a backward-incompatible change since it no longer
distributes host keys by default, but as the referenced issue would
indicate, this role was not actually distributing host keys. Therefore,
I consider this PR to be an enhancement.

fixes #4